### PR TITLE
WP REST API V2: rename register_api_field to register_rest_field

### DIFF
--- a/better-rest-api-featured-images.php
+++ b/better-rest-api-featured-images.php
@@ -40,7 +40,7 @@ function better_rest_api_featured_images_init() {
 		// and supports featured images.
 		if ( $show_in_rest && $supports_thumbnail ) {
 
-			register_api_field( $post_type_name,
+			register_rest_field( $post_type_name,
 				'better_featured_image',
 				array(
 					'get_callback' => 'better_rest_api_featured_images_get_field',


### PR DESCRIPTION
Compatible to WP REST API V2
See https://github.com/WP-API/WP-API/issues/1321
